### PR TITLE
Fix sbenv shell

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -209,7 +209,10 @@ fn activate_environment(quiet: bool) -> Result<()> {
     );
     println!("        export SYFTBOX_OLD_P9K_VISUAL=\"${{POWERLEVEL9K_VIRTUALENV_VISUAL_IDENTIFIER_EXPANSION}}\"");
     println!("        # Override to show box icon and email without 'Py'");
-    println!("        export POWERLEVEL9K_VIRTUALENV_CONTENT_EXPANSION='📦 {}'", config.email);
+    println!(
+        "        export POWERLEVEL9K_VIRTUALENV_CONTENT_EXPANSION='📦 {}'",
+        config.email
+    );
     println!("        export POWERLEVEL9K_VIRTUALENV_VISUAL_IDENTIFIER_EXPANSION=''");
     println!("        export POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false");
     println!("        export POWERLEVEL9K_VIRTUALENV_SHOW_WITH_PYENV=false");
@@ -225,7 +228,10 @@ fn activate_environment(quiet: bool) -> Result<()> {
     println!("    export PS1=\"📦 ($SYFTBOX_ENV_NAME) $PS1\"");
     println!("fi");
 
-    println!("echo \"SyftBox environment activated: {}\" >&2", config.email);
+    println!(
+        "echo \"SyftBox environment activated: {}\" >&2",
+        config.email
+    );
 
     // Force Powerlevel10k to refresh if it's running
     println!("if typeset -f _p9k_precmd >/dev/null 2>&1; then");
@@ -499,11 +505,19 @@ fn get_shell_functions() -> String {
     functions.push_str("    case \"$1\" in\n");
     functions.push_str("        activate)\n");
     functions.push_str("            eval \"$(command sbenv activate --quiet)\"\n");
-    functions.push_str("            # Fix Powerlevel10k prompt to show 📦 and email instead of 'Py'\n");
-    functions.push_str("            if [[ -n \"$ZSH_VERSION\" ]] && [[ -n \"$SYFTBOX_EMAIL\" ]]; then\n");
-    functions.push_str("                export POWERLEVEL9K_VIRTUALENV_CONTENT_EXPANSION=\"📦 $SYFTBOX_EMAIL\"\n");
-    functions.push_str("                export POWERLEVEL9K_VIRTUALENV_VISUAL_IDENTIFIER_EXPANSION=''\n");
-    functions.push_str("                export POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false\n");
+    functions
+        .push_str("            # Fix Powerlevel10k prompt to show 📦 and email instead of 'Py'\n");
+    functions.push_str(
+        "            if [[ -n \"$ZSH_VERSION\" ]] && [[ -n \"$SYFTBOX_EMAIL\" ]]; then\n",
+    );
+    functions.push_str(
+        "                export POWERLEVEL9K_VIRTUALENV_CONTENT_EXPANSION=\"📦 $SYFTBOX_EMAIL\"\n",
+    );
+    functions.push_str(
+        "                export POWERLEVEL9K_VIRTUALENV_VISUAL_IDENTIFIER_EXPANSION=''\n",
+    );
+    functions
+        .push_str("                export POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false\n");
     functions.push_str("                export POWERLEVEL9K_VIRTUALENV_SHOW_WITH_PYENV=false\n");
     functions.push_str("                # Force P10k to rebuild its prompt cache\n");
     functions.push_str("                unset _p9k__cached_p10k_param_sig 2>/dev/null\n");
@@ -518,8 +532,11 @@ fn get_shell_functions() -> String {
     functions.push_str("            eval \"$(command sbenv deactivate --quiet)\"\n");
     functions.push_str("            # Reset P10k virtualenv display\n");
     functions.push_str("            if [[ -n \"$ZSH_VERSION\" ]]; then\n");
-    functions.push_str("                export POWERLEVEL9K_VIRTUALENV_CONTENT_EXPANSION='${VIRTUAL_ENV:t}'\n");
-    functions.push_str("                export POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false\n");
+    functions.push_str(
+        "                export POWERLEVEL9K_VIRTUALENV_CONTENT_EXPANSION='${VIRTUAL_ENV:t}'\n",
+    );
+    functions
+        .push_str("                export POWERLEVEL9K_VIRTUALENV_SHOW_PYTHON_VERSION=false\n");
     functions.push_str("                unset _p9k__cached_p10k_param_sig 2>/dev/null\n");
     functions.push_str("                if typeset -f p10k >/dev/null 2>&1; then\n");
     functions.push_str("                    p10k reload 2>/dev/null\n");


### PR DESCRIPTION
- Updated shell wrapper function to override P10k settings after activation
- Changed environment name to use email for better identification
- Fixed P10k cache clearing to properly refresh prompt
- Prompt now shows '📦 user@example.com' instead of 'Py'

## Description
Please include a summary of the change, the motivation, and any additional context that will help others understand your PR. If it closes one or more open issues, [please tag them as described here](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
